### PR TITLE
Added ISR implmentation with payload hooks

### DIFF
--- a/apps/frontend/src/app/(frontend)/blogs/[...blogs]/page.tsx
+++ b/apps/frontend/src/app/(frontend)/blogs/[...blogs]/page.tsx
@@ -1,7 +1,7 @@
 import { draftMode } from 'next/headers'
 import React from 'react'
 import BlogRenderer from '@/components/blogs/blog-renderer/BlogRenderer'
-import { fetchBlogView, pageData } from '@/lib/fetch-utils'
+import { fetchBlogView, pageData, queryPagesSlug } from '@/lib/fetch-utils'
 import { Props } from '@/lib/types'
 import { contructImageUrl } from '@/lib/utils'
 import { Metadata } from 'next'
@@ -41,6 +41,12 @@ export async function generateMetadata({ params }: Props) {
   return metadata
 }
 
+export async function generateStaticParams() {
+ const pages = await queryPagesSlug()
+ const slugs = pages?.docs.map((page) => ({ slug: page.slug })) || []
+ return slugs
+}
+
 const page = async ({ params }: Props) => {
   const { isEnabled: draft } = await draftMode()
   const page = await pageData(params)
@@ -61,3 +67,5 @@ const page = async ({ params }: Props) => {
 }
 
 export default page
+
+export const revalidate = 60; // fallback interval, in seconds

--- a/apps/frontend/src/app/api/revalidate/route.ts
+++ b/apps/frontend/src/app/api/revalidate/route.ts
@@ -1,0 +1,19 @@
+// app/api/revalidate/route.js
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { path, secret } = await req.json();
+
+    if (secret !== process.env.REVALIDATE_SECRET) {
+      return NextResponse.json({ message: "Invalid token" }, { status: 401 });
+    }
+
+    revalidatePath(path);
+
+    return NextResponse.json({ revalidated: true, path });
+  } catch (err) {
+    return NextResponse.json({ message: "Error revalidating", error: err instanceof Error ? err.message : 'Unknown error' }, { status: 500 });
+  }
+}

--- a/apps/frontend/src/collections/Page.ts
+++ b/apps/frontend/src/collections/Page.ts
@@ -50,5 +50,46 @@ export const Page: CollectionConfig = {
       tabs: [Content, SeoTab],
     },
   ],
+  hooks: {
+    afterChange: [
+      async ({ doc }) => {
+        const path = `/blog/${doc.slug}`;
+
+        // Call Next.js revalidate API
+        await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/revalidate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            path,
+            secret: process.env.REVALIDATE_SECRET,
+          }),
+        });
+      },
+    ],
+    afterDelete: [
+      async ({ doc }) => {
+        const path = `/blog/${doc.slug}`;
+
+        await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/revalidate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            path,
+            secret: process.env.REVALIDATE_SECRET,
+          }),
+        });
+
+        // Also revalidate blog listing page
+        await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/revalidate`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            path: "/blog",
+            secret: process.env.REVALIDATE_SECRET,
+          }),
+        });
+      },
+    ],
+  },
   trash: true,
 }

--- a/apps/frontend/src/lib/fetch-utils.ts
+++ b/apps/frontend/src/lib/fetch-utils.ts
@@ -88,3 +88,28 @@ export const queryPages = async () => {
     }
   }
 }
+
+export const queryPagesSlug = async () => {
+  const payload = await getPayload({ config: config })
+
+  const result = await payload.find({
+    collection: 'pages',
+    depth: 2,
+    pagination: false,
+    where: {
+      slug: {
+        contains: `blogs`,
+      },
+    },
+    select: {
+      slug: true,
+    },
+  })
+
+  if (result.docs?.[0]) {
+    return {
+      type: 'page',
+      docs: result.docs,
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"],
-      "env": ["PREVIEW_SECRET", "PAYLOAD_SECRET", "DATABASE_URI", "NEXTAUTH_SECRET", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET","BACKEND_URL","ENCRYPTION_SECRET"]
+      "env": ["PREVIEW_SECRET", "PAYLOAD_SECRET", "DATABASE_URI", "NEXTAUTH_SECRET", "GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET","BACKEND_URL","ENCRYPTION_SECRET", "REVALIDATE_SECRET"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
Added ISR implmentation with payload hooks
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Implemented ISR with on-demand revalidation for blog pages using Next.js and Payload hooks. Blog edits and deletes now update the site quickly without a redeploy.

- New Features
  - Prebuilds blog pages via generateStaticParams; sets revalidate = 60 for fallback ISR.
  - Adds POST /api/revalidate to trigger revalidatePath using a secret.
  - Payload Page hooks revalidate /blog/[slug] on create/update/delete and /blog on delete.
  - Adds queryPagesSlug to fetch blog slugs for static params.
  - Passes REVALIDATE_SECRET through turbo env.

- Migration
  - Set REVALIDATE_SECRET in the frontend runtime and build envs.
  - Set NEXT_PUBLIC_SITE_URL to the public frontend URL so hooks can call /api/revalidate.
  - Optional: trigger a build or first-load to warm pages; ISR will cache after first request.

<!-- End of auto-generated description by cubic. -->

