### PR TITLE
Updated presentation view for analytics tab

### DIFF
--- a/apps/frontend/src/app/(payload)/admin/importMap.js
+++ b/apps/frontend/src/app/(payload)/admin/importMap.js
@@ -32,7 +32,8 @@ import { MetaTitleComponent as MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c08
 import { MetaImageComponent as MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
 import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from '@payloadcms/plugin-seo/client'
-import { default as default_b4de4c47b515a7c585ab57f4c4dd69c3 } from '@/components/payload/dashboard/pagespeed'
+import { default as default_5e8629dff80dac03d9275dce6ee68383 } from '@/components/payload/dashboard/view-and-reactions/ViewsAndReactions'
+import { default as default_76aa9e21c065ea9b0a4461df1322defb } from '@/components/payload/dashboard/pagespeed/pagespeed'
 import { FolderTypeField as FolderTypeField_3817bf644402e67bfe6577f60ef982de } from '@payloadcms/ui'
 import { UploadthingClientUploadHandler as UploadthingClientUploadHandler_749dcaa11bb61b873d113cb6c609bc10 } from '@payloadcms/storage-uploadthing/client'
 
@@ -71,7 +72,8 @@ export const importMap = {
   "@payloadcms/plugin-seo/client#MetaImageComponent": MetaImageComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaDescriptionComponent": MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#PreviewComponent": PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
-  "@/components/payload/dashboard/pagespeed#default": default_b4de4c47b515a7c585ab57f4c4dd69c3,
+  "@/components/payload/dashboard/view-and-reactions/ViewsAndReactions#default": default_5e8629dff80dac03d9275dce6ee68383,
+  "@/components/payload/dashboard/pagespeed/pagespeed#default": default_76aa9e21c065ea9b0a4461df1322defb,
   "@payloadcms/ui#FolderTypeField": FolderTypeField_3817bf644402e67bfe6577f60ef982de,
   "@payloadcms/storage-uploadthing/client#UploadthingClientUploadHandler": UploadthingClientUploadHandler_749dcaa11bb61b873d113cb6c609bc10
 }

--- a/apps/frontend/src/collections/Page.ts
+++ b/apps/frontend/src/collections/Page.ts
@@ -48,14 +48,13 @@ export const Page: CollectionConfig = {
     },
     {
       name: 'revalidate',
-      type: 'text',
+      type: 'ui',
       label: 'Revalidate',
-      defaultValue: 'blogs',
       admin: {
-        readOnly: true,
         components: {
-          afterInput: ['@/components/payload/dashboard/revalidation'],
+          Field: '@/components/payload/dashboard/revalidation',
         },
+        position: 'sidebar',
       },
     },
     {
@@ -65,6 +64,8 @@ export const Page: CollectionConfig = {
   ],
   trash: true,
   versions: {
-    drafts: true,
+    drafts: {
+      autosave: true,
+    },
   },
 }

--- a/apps/frontend/src/collections/blocks/analytics.tsx
+++ b/apps/frontend/src/collections/blocks/analytics.tsx
@@ -4,117 +4,47 @@ export const Analytics: Tab = {
   name: 'analytics',
   fields: [
     {
-      name: 'views',
-      type: 'number',
-      admin: {
-        readOnly: true,
-      },
-      hooks: {
-        afterRead: [
-          async ({ data, value }) => {
-            if (data) {
-              const response = await fetch(
-                `${process.env.NEXT_PUBLIC_BACKEND_URL}/blogs/get/views?id=${data.id}`,
-                {
-                  method: 'GET',
-                  headers: {
-                    'Content-Type': 'application/json',
-                  },
-                },
-              )
-              const blogViews = await response.json()
-              value = blogViews.blogsCount
-            }
-            return value
+      type: 'collapsible',
+      label: 'Views and Reactions',
+      fields: [
+        {
+          name: 'viewAndReactions',
+          type: 'ui',
+          admin: {
+            components: {
+              Field: '@/components/payload/dashboard/view-and-reactions/ViewsAndReactions',
+            },
           },
-        ],
-      },
-    },
-    {
-      name: 'reactions',
-      type: 'number',
-      admin: {
-        readOnly: true,
-      },
-      hooks: {
-        afterRead: [
-          async ({ data, value }) => {
-            if (data) {
-              const response = await fetch(
-                `${process.env.NEXT_PUBLIC_BACKEND_URL}/blogs/get/reactions-count-from-blog?id=${data.id}`,
-                {
-                  method: 'GET',
-                  headers: {
-                    'Content-Type': 'application/json',
-                  },
-                },
-              )
-              const blogReactions = await response.json()
-              value = blogReactions.reactionsCount
-            }
-            return value
+        },
+        {
+          name: 'views',
+          type: 'text',
+          admin: {
+            readOnly: true,
+            hidden: true,
           },
-        ],
-      },
+        },
+        {
+          name: 'reactions',
+          type: 'text',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+      ]
     },
     {
       type: 'collapsible',
       label: 'Page Speed',
       fields: [
         {
-          name: 'lcp',
-          type: 'text',
-          label: 'Largest Contentful Paint (Read Only)',
+          name: 'pagespeedScore',
+          type: 'ui',
           admin: {
-            readOnly: true,
-          },
-        },
-        {
-          name: 'fcp',
-          type: 'text',
-          label: 'First Contentful Paint (Read Only)',
-          admin: {
-            readOnly: true,
-          },
-        },
-        {
-          name: 'cls',
-          type: 'text',
-          label: 'Cumulative Layout Shift (Read Only)',
-          admin: {
-            readOnly: true,
-          },
-        },
-        {
-          name: 'interactive',
-          type: 'text',
-          label: 'Time to Interactive (Read Only)',
-          admin: {
-            readOnly: true,
-          },
-        },
-        {
-          name: 'totalBlockingTime',
-          type: 'text',
-          label: 'Total Blocking Time (Read Only)',
-          admin: {
-            readOnly: true,
-          },
-        },
-        {
-          name: 'speedIndex',
-          type: 'text',
-          label: 'Speed Index (Read Only)',
-          admin: {
-            readOnly: true,
-          },
-        },
-        {
-          name: 'serverResponseTime',
-          type: 'text',
-          label: 'Server Response Time (Read Only)',
-          admin: {
-            readOnly: true,
+            components: {
+              Field: '@/components/payload/dashboard/pagespeed/pagespeed',
+            },
           },
         },
         {
@@ -123,9 +53,79 @@ export const Analytics: Tab = {
           label: 'Pagespeed performance score (Read Only)',
           admin: {
             readOnly: true,
-            components: {
-              afterInput: ['@/components/payload/dashboard/pagespeed'],
-            },
+            hidden: true,
+          },
+        },
+        {
+          name: 'domSize',
+          type: 'number',
+          label: 'DOM Size (Read Only)',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+        {
+          name: 'lcp',
+          type: 'text',
+          label: 'Largest Contentful Paint (Read Only)',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+        {
+          name: 'fcp',
+          type: 'text',
+          label: 'First Contentful Paint (Read Only)',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+        {
+          name: 'cls',
+          type: 'text',
+          label: 'Cumulative Layout Shift (Read Only)',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+        {
+          name: 'interactive',
+          type: 'text',
+          label: 'Time to Interactive (Read Only)',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+        {
+          name: 'totalBlockingTime',
+          type: 'text',
+          label: 'Total Blocking Time (Read Only)',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+        {
+          name: 'speedIndex',
+          type: 'text',
+          label: 'Speed Index (Read Only)',
+          admin: {
+            readOnly: true,
+            hidden: true,
+          },
+        },
+        {
+          name: 'serverResponseTime',
+          type: 'text',
+          label: 'Server Response Time (Read Only)',
+          admin: {
+            readOnly: true,
+            hidden: true,
           },
         },
       ],

--- a/apps/frontend/src/components/payload/dashboard/pagespeed/styles.scss
+++ b/apps/frontend/src/components/payload/dashboard/pagespeed/styles.scss
@@ -1,5 +1,5 @@
 .pagespeed-container {
-  margin-top: 20px;
+  margin: 20px 0;
   padding: 24px;
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   border-radius: 16px;
@@ -8,6 +8,7 @@
   border: 1px solid rgba(255, 255, 255, 0.1);
 
   .fetch-button {
+    width: 100%;
     background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
     color: white;
     border: none;

--- a/apps/frontend/src/components/payload/dashboard/view-and-reactions/ViewsAndReactions.tsx
+++ b/apps/frontend/src/components/payload/dashboard/view-and-reactions/ViewsAndReactions.tsx
@@ -1,0 +1,99 @@
+'use client'
+import { useDocumentInfo, useField, useForm } from '@payloadcms/ui'
+import React, { useState } from 'react'
+import './style.scss'
+
+const getViewsAndReactions = async ({ id }: { id: string }) => {
+  const viewsResponse = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_URL}/blogs/get/views?id=${id}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  )
+  const reactionsResponse = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_URL}/blogs/get/reactions-count-from-blog?id=${id}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  )
+  const blogReactions = await reactionsResponse.json()
+  const blogViews = await viewsResponse.json()
+
+  return {
+    views: blogViews.blogsCount,
+    reactions: blogReactions.reactionsCount,
+  }
+}
+
+export default function ViewsAndReactions({ path }: { path: string }) {
+  const [loading, setLoading] = useState(false)
+  const formFields = useForm()
+  const documentInfo = useDocumentInfo()
+
+  const reactions = useField<string>({ path: 'analytics.reactions' })
+  const views = useField<string>({ path: 'analytics.views' })
+
+  const { setValue } = useField({ path })
+
+  const handleGetViewsAndReactions = () => {
+    setLoading(true)
+    const documentId = documentInfo?.data?.id
+    getViewsAndReactions({ id: documentId as string })
+      .then((data) => {
+        setValue("UI Render")
+        formFields.dispatchFields({
+          type: 'UPDATE',
+          path: 'analytics.reactions',
+          value: data.reactions,
+        })
+        formFields.dispatchFields({
+          type: 'UPDATE',
+          path: 'analytics.views',
+          value: data.views,
+        })
+      })
+      .catch((error) => {
+        console.error('Failed to fetch views and reactions:', error)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }
+
+  return (
+    <div className="views-reactions-container">
+      <div className="card-wrapper">
+        <div className="analytics-card">
+          <div className="card-header">
+            <h1>Views and Reactions</h1>
+          </div>
+          <div className="card-body">
+            <button
+              className="action-button"
+              disabled={loading}
+              onClick={handleGetViewsAndReactions}
+            >
+              {loading ? '🔄 Getting Views and Reactions...' : '🔄 Get Views and Reactions'}
+            </button>
+            <div className="stats-container">
+              <div className="stat-item views-stat">
+                <span className="stat-label">👁️ Views</span>
+                <span className="stat-value">{views.value || '0'}</span>
+              </div>
+              <div className="stat-item reactions-stat">
+                <span className="stat-label">❤️ Reactions</span>
+                <span className="stat-value">{reactions.value || '0'}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/payload/dashboard/view-and-reactions/style.scss
+++ b/apps/frontend/src/components/payload/dashboard/view-and-reactions/style.scss
@@ -1,0 +1,216 @@
+.views-reactions-container {
+  margin: 20px 0;
+  padding: 0;
+
+  .card-wrapper {
+    display: block;
+    width: 100%;
+  }
+
+  .analytics-card {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 16px;
+    padding: 32px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    position: relative;
+    width: 100%;
+
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 24px;
+      padding-bottom: 16px;
+      border-bottom: 2px solid rgba(255, 255, 255, 0.2);
+
+      h1 {
+        margin: 0;
+        font-size: 24px;
+        font-weight: 700;
+        color: #ffffff;
+        background: linear-gradient(135deg, #ffffff 0%, #f0f0f0 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+      }
+    }
+
+    .card-body {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+
+      .action-button {
+        background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+        color: white;
+        border: none;
+        padding: 14px 28px;
+        border-radius: 12px;
+        font-weight: 600;
+        font-size: 15px;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        box-shadow: 0 4px 15px rgba(79, 172, 254, 0.3);
+        position: relative;
+        overflow: hidden;
+        width: 100%;
+
+        &:hover:not(:disabled) {
+          transform: translateY(-2px);
+          box-shadow: 0 8px 25px rgba(79, 172, 254, 0.4);
+        }
+
+        &:active:not(:disabled) {
+          transform: translateY(0);
+        }
+
+        &:disabled {
+          opacity: 0.7;
+          cursor: not-allowed;
+          transform: none;
+        }
+
+        &::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: -100%;
+          width: 100%;
+          height: 100%;
+          background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+          transition: left 0.5s;
+        }
+
+        &:hover:not(:disabled)::before {
+          left: 100%;
+        }
+      }
+
+      .stats-container {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        margin-top: 8px;
+
+        .stat-item {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          padding: 16px 20px;
+          background: rgba(255, 255, 255, 0.1);
+          border-radius: 12px;
+          backdrop-filter: blur(5px);
+          border: 1px solid rgba(255, 255, 255, 0.2);
+          transition: all 0.3s ease;
+          color: #ffffff;
+
+          &:hover {
+            background: rgba(255, 255, 255, 0.15);
+            transform: translateX(4px);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+          }
+
+          .stat-label {
+            font-weight: 500;
+            font-size: 15px;
+            opacity: 0.9;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+
+            &::before {
+              content: '';
+              width: 8px;
+              height: 8px;
+              border-radius: 50%;
+              background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+              display: inline-block;
+            }
+          }
+
+          .stat-value {
+            font-weight: 700;
+            font-size: 20px;
+            color: #ffffff;
+            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+          }
+
+          &.views-stat {
+            border-left: 4px solid #4facfe;
+
+            .stat-label::before {
+              background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+            }
+          }
+
+          &.reactions-stat {
+            border-left: 4px solid #ff6b6b;
+
+            .stat-label::before {
+              background: linear-gradient(135deg, #ff6b6b 0%, #ee5a6f 100%);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Responsive design
+@media (max-width: 768px) {
+  .views-reactions-container {
+    margin-top: 16px;
+
+    .analytics-card {
+      padding: 24px;
+      border-radius: 12px;
+
+      .card-header {
+        margin-bottom: 20px;
+        padding-bottom: 12px;
+
+        h1 {
+          font-size: 20px;
+        }
+      }
+
+      .card-body {
+        gap: 16px;
+
+        .action-button {
+          padding: 16px 24px;
+          font-size: 16px;
+        }
+
+        .stats-container {
+          gap: 12px;
+
+          .stat-item {
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 8px;
+            padding: 14px 16px;
+
+            .stat-label {
+              font-size: 14px;
+            }
+
+            .stat-value {
+              font-size: 24px;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Dark theme support
+@media (prefers-color-scheme: dark) {
+  .views-reactions-container {
+    .analytics-card {
+      background: linear-gradient(135deg, #2d3748 0%, #4a5568 100%);
+    }
+  }
+}

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -206,7 +206,6 @@ export interface Page {
   id: string;
   pageTitle: string;
   slug: string;
-  revalidate?: string | null;
   content: {
     title: string;
     shortDescription: string;
@@ -274,8 +273,10 @@ export interface Page {
   };
   seo: Seo;
   analytics?: {
-    views?: number | null;
-    reactions?: number | null;
+    views?: string | null;
+    reactions?: string | null;
+    pagespeed?: number | null;
+    domSize?: number | null;
     lcp?: string | null;
     fcp?: string | null;
     cls?: string | null;
@@ -283,7 +284,6 @@ export interface Page {
     totalBlockingTime?: string | null;
     speedIndex?: string | null;
     serverResponseTime?: string | null;
-    pagespeed?: number | null;
   };
   folder?: (string | null) | FolderInterface;
   updatedAt: string;
@@ -419,7 +419,6 @@ export interface MediaSelect<T extends boolean = true> {
 export interface PagesSelect<T extends boolean = true> {
   pageTitle?: T;
   slug?: T;
-  revalidate?: T;
   content?:
     | T
     | {
@@ -474,6 +473,8 @@ export interface PagesSelect<T extends boolean = true> {
     | {
         views?: T;
         reactions?: T;
+        pagespeed?: T;
+        domSize?: T;
         lcp?: T;
         fcp?: T;
         cls?: T;
@@ -481,7 +482,6 @@ export interface PagesSelect<T extends boolean = true> {
         totalBlockingTime?: T;
         speedIndex?: T;
         serverResponseTime?: T;
-        pagespeed?: T;
       };
   folder?: T;
   updatedAt?: T;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redesigned the Analytics tab with new UI cards for Views/Reactions and PageSpeed, fetching metrics on demand for a clearer, faster workflow. Moved revalidation to the sidebar UI and enabled autosave for drafts.

- New Features
  - Views & Reactions: added a UI card with a fetch button; stores values in hidden read-only fields.
  - PageSpeed: added a UI card with a fetch button; displays Lighthouse metrics (including DOM Size) and performance score.
  - Page collection: revalidation control moved to a sidebar UI field; drafts autosave enabled.

- Refactors
  - Replaced afterRead hooks with client UI components; updated import map and file structure.
  - Adjusted types: analytics.views and analytics.reactions are now strings; added pagespeed and domSize fields.
  - Updated styles and made action buttons full-width.

<sup>Written for commit 8e74557f5f1da316b27b99f3796497cdbf3de564. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

