### PR TITLE
Image preview feature using form field api

### DIFF
--- a/apps/frontend/src/app/(payload)/admin/importMap.js
+++ b/apps/frontend/src/app/(payload)/admin/importMap.js
@@ -1,3 +1,4 @@
+import { default as default_bea000b683b1542f619ebdf784e53c32 } from '@/components/payload/dashboard/ImagePreview'
 import { default as default_d86150a9e1be19c6b36cbda2cd68dd31 } from '@/components/payload/dashboard/revalidation'
 import { default as default_d5a885890ed1172f8ed1ecdf3f4ebb6a } from '@/components/payload/dashboard/ArrayRowLabel'
 import { default as default_a84e65d5054455783144789857df1211 } from '@/components/payload/dashboard/ai-summary/GeminiFieldSummary'
@@ -38,6 +39,7 @@ import { UploadthingClientUploadHandler as UploadthingClientUploadHandler_749dca
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 export const importMap = {
+  "@/components/payload/dashboard/ImagePreview#default": default_bea000b683b1542f619ebdf784e53c32,
   "@/components/payload/dashboard/revalidation#default": default_d86150a9e1be19c6b36cbda2cd68dd31,
   "@/components/payload/dashboard/ArrayRowLabel#default": default_d5a885890ed1172f8ed1ecdf3f4ebb6a,
   "@/components/payload/dashboard/ai-summary/GeminiFieldSummary#default": default_a84e65d5054455783144789857df1211,

--- a/apps/frontend/src/collections/Media.ts
+++ b/apps/frontend/src/collections/Media.ts
@@ -25,7 +25,7 @@ export const Media: CollectionConfig = {
       hooks: {
         afterRead: [
           ({ data }) => {
-            if (data) {
+            if (data && data._key) {
               const baseUrl = 'https://570pc5yjce.ufs.sh/f/'
               data.cloudUrl = `${baseUrl}${data._key}`;
             }

--- a/apps/frontend/src/collections/Media.ts
+++ b/apps/frontend/src/collections/Media.ts
@@ -21,7 +21,6 @@ export const Media: CollectionConfig = {
         description:
           'This is the URL that will be used to access the image in the cloud storage',
       },
-      defaultValue: `https://570pc5yjce.ufs.sh/f/`,
       required: true,
       hooks: {
         afterRead: [

--- a/apps/frontend/src/collections/Media.ts
+++ b/apps/frontend/src/collections/Media.ts
@@ -35,24 +35,6 @@ export const Media: CollectionConfig = {
       },
     },
     {
-      name:'type',
-      label: 'Media Type',
-      type:'text',
-      required: true,
-      admin: {
-        readOnly: true,
-      },
-      hooks: {
-        beforeValidate: [
-          ({ data }) => {
-            if (data) {
-              data.type = data.mimeType
-            }
-          },
-        ],
-      },
-    },
-    {
       name: 'preview', // required
       type: 'ui', // required
       admin: {

--- a/apps/frontend/src/collections/Media.ts
+++ b/apps/frontend/src/collections/Media.ts
@@ -12,6 +12,55 @@ export const Media: CollectionConfig = {
       type: 'text',
       required: true,
     },
+    {
+      name: 'cloudUrl',
+      type: 'text',
+      label: 'Cloud URL',
+      admin: {
+        readOnly: true,
+        description:
+          'This is the URL that will be used to access the image in the cloud storage',
+      },
+      defaultValue: `https://570pc5yjce.ufs.sh/f/`,
+      required: true,
+      hooks: {
+        afterRead: [
+          ({ data }) => {
+            if (data) {
+              const baseUrl = 'https://570pc5yjce.ufs.sh/f/'
+              data.cloudUrl = `${baseUrl}${data._key}`;
+            }
+          },
+        ],
+      },
+    },
+    {
+      name:'type',
+      label: 'Media Type',
+      type:'text',
+      required: true,
+      admin: {
+        readOnly: true,
+      },
+      hooks: {
+        beforeValidate: [
+          ({ data }) => {
+            if (data) {
+              data.type = data.mimeType
+            }
+          },
+        ],
+      },
+    },
+    {
+      name: 'preview', // required
+      type: 'ui', // required
+      admin: {
+        components: {
+          Field: '@/components/payload/dashboard/ImagePreview',
+        },
+      },
+    },
   ],
   upload: true,
   trash: true,

--- a/apps/frontend/src/components/payload/dashboard/ImagePreview.tsx
+++ b/apps/frontend/src/components/payload/dashboard/ImagePreview.tsx
@@ -5,11 +5,11 @@ import Image from 'next/image'
 
 const ImagePreview = () => {
   const [showPreview, setShowPreview] = useState(false)
-  const cloudUrl = useFormFields(([fields]) => fields.cloudUrl).value as string || ''
+  const cloudUrl = useFormFields(([fields]) => fields.cloudUrl).value as string | null
 
-  const mimeType = useFormFields(([fields]) => fields.mimeType).value as string || ''
+  const mimeType = useFormFields(([fields]) => fields.mimeType).value as string | null
 
-  if(!mimeType.includes('image')) return null
+  if(!mimeType?.includes('image') || !cloudUrl) return null
 
   return (
     <div>

--- a/apps/frontend/src/components/payload/dashboard/ImagePreview.tsx
+++ b/apps/frontend/src/components/payload/dashboard/ImagePreview.tsx
@@ -5,11 +5,11 @@ import Image from 'next/image'
 
 const ImagePreview = () => {
   const [showPreview, setShowPreview] = useState(false)
-  const cloudUrl = useFormFields(([fields]) => fields.cloudUrl).value as string
+  const cloudUrl = useFormFields(([fields]) => fields.cloudUrl).value as string || ''
 
-  const type = useFormFields(([fields]) => fields.type).value as string
+  const mimeType = useFormFields(([fields]) => fields.mimeType).value as string || ''
 
-  if(!type.includes('image')) return null
+  if(!mimeType.includes('image')) return null
 
   return (
     <div>

--- a/apps/frontend/src/components/payload/dashboard/ImagePreview.tsx
+++ b/apps/frontend/src/components/payload/dashboard/ImagePreview.tsx
@@ -1,0 +1,64 @@
+'use client'
+import { useFormFields } from '@payloadcms/ui'
+import { useState } from 'react'
+import Image from 'next/image'
+
+const ImagePreview = () => {
+  const [showPreview, setShowPreview] = useState(false)
+  const cloudUrl = useFormFields(([fields]) => fields.cloudUrl).value as string
+
+  const type = useFormFields(([fields]) => fields.type).value as string
+
+  if(!type.includes('image')) return null
+
+  return (
+    <div>
+      <button
+        onClick={(e) => {
+          e.preventDefault()
+          setShowPreview(!showPreview)
+        }}
+      >
+        {showPreview ? 'Hide Preview' : 'Show Preview'}
+      </button>
+      {showPreview ? (
+        <div
+          style={{
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            zIndex: 1000,
+            display: 'flex',
+            alignItems: 'start',
+            justifyContent: 'center',
+            gap: '10px',
+          }}
+        >
+          <Image src={cloudUrl} alt="Image" width={1000} height={1000} style={{ width: '100%', height: 'auto', borderRadius: '10px', border: '1px solid #4facfe', boxShadow: '0 0 10px 0 rgba(0, 0, 0, 0.1)' }} />
+          <button
+            onClick={(e) => {
+              e.preventDefault()
+              setShowPreview(false)
+            }}
+            style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: '20px',
+                fontWeight: 'bold',
+                color: 'white',
+                padding: '10px',
+                borderRadius: '50%',
+                width: '30px',
+            }}
+          >
+            X
+          </button>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default ImagePreview

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -160,6 +160,11 @@ export interface User {
 export interface Media {
   id: string;
   alt: string;
+  /**
+   * This is the URL that will be used to access the image in the cloud storage
+   */
+  cloudUrl: string;
+  type: string;
   _key?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -431,6 +436,8 @@ export interface UsersSelect<T extends boolean = true> {
  */
 export interface MediaSelect<T extends boolean = true> {
   alt?: T;
+  cloudUrl?: T;
+  type?: T;
   _key?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -164,7 +164,6 @@ export interface Media {
    * This is the URL that will be used to access the image in the cloud storage
    */
   cloudUrl: string;
-  type: string;
   _key?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -437,7 +436,6 @@ export interface UsersSelect<T extends boolean = true> {
 export interface MediaSelect<T extends boolean = true> {
   alt?: T;
   cloudUrl?: T;
-  type?: T;
   _key?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an image preview toggle in the Media admin via a `preview` UI field. Adds a read-only `cloudUrl` and uses `mimeType` directly for filtering (removed the extra `type` field).

- New Features
  - `ImagePreview` component renders in Media via a `ui` field; toggles an overlay preview for image files using `@payloadcms/ui` and `next/image`.
  - Read-only `cloudUrl` (required) computed from base + `_key` in `afterRead`, with a failsafe when `_key` is missing.
  - Component registered in admin `importMap` and types updated in `payload-types.ts`; removed `type` and rely on `mimeType`.

<sup>Written for commit 2164a56420440152f079b5ae9f650daea0a85791. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image preview added to Media admin interface for quick visual inspection.
  * New read-only Cloud URL shown for media items (auto-computed from base URL + identifier).
* **Chores**
  * Media type definitions updated to include the new Cloud URL field for queries and selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->