### PR TITLE
build: introduced folder feature in dashboard

### DIFF
--- a/apps/frontend/src/app/(payload)/admin/importMap.js
+++ b/apps/frontend/src/app/(payload)/admin/importMap.js
@@ -1,4 +1,6 @@
 import { default as default_bea000b683b1542f619ebdf784e53c32 } from '@/components/payload/dashboard/ImagePreview'
+import { FolderTableCell as FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
+import { FolderField as FolderField_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 import { default as default_d86150a9e1be19c6b36cbda2cd68dd31 } from '@/components/payload/dashboard/revalidation'
 import { default as default_d5a885890ed1172f8ed1ecdf3f4ebb6a } from '@/components/payload/dashboard/ArrayRowLabel'
 import { default as default_a84e65d5054455783144789857df1211 } from '@/components/payload/dashboard/ai-summary/GeminiFieldSummary'
@@ -34,12 +36,15 @@ import { PreviewComponent as PreviewComponent_a8a977ebc872c5d5ea7ee689724c0860 }
 import { default as default_5e8629dff80dac03d9275dce6ee68383 } from '@/components/payload/dashboard/view-and-reactions/ViewsAndReactions'
 import { default as default_76aa9e21c065ea9b0a4461df1322defb } from '@/components/payload/dashboard/pagespeed/pagespeed'
 import { default as default_343f7dd89d93a9641fcb5e5552851cc0 } from '@/components/payload/dashboard/csv-export/CsvDataExport'
+import { FolderTypeField as FolderTypeField_2b8867833a34864a02ddf429b0728a40 } from '@payloadcms/next/client'
 import { default as default_7ef9d54d7e43adad90c2fc9dc6f21ba8 } from '@/globals/RefetchButton'
 import { UploadthingClientUploadHandler as UploadthingClientUploadHandler_749dcaa11bb61b873d113cb6c609bc10 } from '@payloadcms/storage-uploadthing/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 export const importMap = {
   "@/components/payload/dashboard/ImagePreview#default": default_bea000b683b1542f619ebdf784e53c32,
+  "@payloadcms/next/rsc#FolderTableCell": FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1,
+  "@payloadcms/next/rsc#FolderField": FolderField_f9c02e79a4aed9a3924487c0cd4cafb1,
   "@/components/payload/dashboard/revalidation#default": default_d86150a9e1be19c6b36cbda2cd68dd31,
   "@/components/payload/dashboard/ArrayRowLabel#default": default_d5a885890ed1172f8ed1ecdf3f4ebb6a,
   "@/components/payload/dashboard/ai-summary/GeminiFieldSummary#default": default_a84e65d5054455783144789857df1211,
@@ -75,6 +80,7 @@ export const importMap = {
   "@/components/payload/dashboard/view-and-reactions/ViewsAndReactions#default": default_5e8629dff80dac03d9275dce6ee68383,
   "@/components/payload/dashboard/pagespeed/pagespeed#default": default_76aa9e21c065ea9b0a4461df1322defb,
   "@/components/payload/dashboard/csv-export/CsvDataExport#default": default_343f7dd89d93a9641fcb5e5552851cc0,
+  "@payloadcms/next/client#FolderTypeField": FolderTypeField_2b8867833a34864a02ddf429b0728a40,
   "@/globals/RefetchButton#default": default_7ef9d54d7e43adad90c2fc9dc6f21ba8,
   "@payloadcms/storage-uploadthing/client#UploadthingClientUploadHandler": UploadthingClientUploadHandler_749dcaa11bb61b873d113cb6c609bc10,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1

--- a/apps/frontend/src/collections/Media.ts
+++ b/apps/frontend/src/collections/Media.ts
@@ -45,4 +45,5 @@ export const Media: CollectionConfig = {
   ],
   upload: true,
   trash: true,
+  folders: true
 }

--- a/apps/frontend/src/payload-types.ts
+++ b/apps/frontend/src/payload-types.ts
@@ -73,11 +73,16 @@ export interface Config {
     collaborators: Collaborator;
     subscribers: Subscriber;
     'payload-kv': PayloadKv;
+    'payload-folders': FolderInterface;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
-  collectionsJoins: {};
+  collectionsJoins: {
+    'payload-folders': {
+      documentsAndFolders: 'payload-folders' | 'media';
+    };
+  };
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     media: MediaSelect<false> | MediaSelect<true>;
@@ -85,6 +90,7 @@ export interface Config {
     collaborators: CollaboratorsSelect<false> | CollaboratorsSelect<true>;
     subscribers: SubscribersSelect<false> | SubscribersSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
+    'payload-folders': PayloadFoldersSelect<false> | PayloadFoldersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
     'payload-migrations': PayloadMigrationsSelect<false> | PayloadMigrationsSelect<true>;
@@ -165,6 +171,7 @@ export interface Media {
    */
   cloudUrl: string;
   _key?: string | null;
+  folder?: (string | null) | FolderInterface;
   updatedAt: string;
   createdAt: string;
   deletedAt?: string | null;
@@ -177,6 +184,32 @@ export interface Media {
   height?: number | null;
   focalX?: number | null;
   focalY?: number | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-folders".
+ */
+export interface FolderInterface {
+  id: string;
+  name: string;
+  folder?: (string | null) | FolderInterface;
+  documentsAndFolders?: {
+    docs?: (
+      | {
+          relationTo?: 'payload-folders';
+          value: string | FolderInterface;
+        }
+      | {
+          relationTo?: 'media';
+          value: string | Media;
+        }
+    )[];
+    hasNextPage?: boolean;
+    totalDocs?: number;
+  };
+  folderType?: 'media'[] | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -363,6 +396,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'subscribers';
         value: string | Subscriber;
+      } | null)
+    | ({
+        relationTo: 'payload-folders';
+        value: string | FolderInterface;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -437,6 +474,7 @@ export interface MediaSelect<T extends boolean = true> {
   alt?: T;
   cloudUrl?: T;
   _key?: T;
+  folder?: T;
   updatedAt?: T;
   createdAt?: T;
   deletedAt?: T;
@@ -581,6 +619,18 @@ export interface SubscribersSelect<T extends boolean = true> {
 export interface PayloadKvSelect<T extends boolean = true> {
   key?: T;
   data?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-folders_select".
+ */
+export interface PayloadFoldersSelect<T extends boolean = true> {
+  name?: T;
+  folder?: T;
+  documentsAndFolders?: T;
+  folderType?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds folder support to the Media collection and admin dashboard so uploads can be organized into folders. Integrates folder UI components and updates generated types to include `payload-folders`.

- **New Features**
  - Enables `folders: true` on `media` to allow folder organization.
  - Registers `FolderField`, `FolderTableCell` (`@payloadcms/next/rsc`) and `FolderTypeField` (`@payloadcms/next/client`) in the admin import map.
  - Extends generated types with `payload-folders` (`FolderInterface`), adds `folder` relation on `media`, and updates selects/joins for folder-aware queries.

<sup>Written for commit ddd5ab31530b1fd0d9a7344941e82371cbb4a833. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media collection now supports folder organization, enabling users to create and manage folders for better media asset organization and navigation within the Media library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->